### PR TITLE
Migrate remaining scripts from `okdata-scripts`

### DIFF
--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -2,11 +2,15 @@ Metadata Scripts
 ===================
 
 Python scripts for enriching, migrating and deleting metadata. Files in this directory are NOT supposed to be included in deployment.
-Purpose of writing scripts here is to utilize existing code in the metadata module. Puspose of keeping the scripts, although they typically only need to be run once,
+Purpose of writing scripts here is to utilize existing code in the metadata module. Purpose of keeping the scripts, although they typically only need to be run once,
 is for traceability.
 
 ## Scripts
 
+* `migrate_dataset_processing_stage`
+  * This script was used to physically move from from one dataset processing stage to another.
+* `remove_processing_stage`
+  * This script was used to remove the `processing_stage` field from the dataset metadata.
 * `set_event_source`
   * This script was used to set source.type = event for all datasets with event streams.
 * `set_file_source`

--- a/scripts/SCRIPTS.md
+++ b/scripts/SCRIPTS.md
@@ -8,7 +8,7 @@ is for traceability.
 ## Scripts
 
 * `migrate_dataset_processing_stage`
-  * This script was used to physically move from from one dataset processing stage to another.
+  * This script was used to physically move from one dataset processing stage to another.
 * `remove_processing_stage`
   * This script was used to remove the `processing_stage` field from the dataset metadata.
 * `set_event_source`

--- a/scripts/migrate_dataset_processing_stage.py
+++ b/scripts/migrate_dataset_processing_stage.py
@@ -1,0 +1,125 @@
+import boto3
+import requests
+from boto3.dynamodb.conditions import Attr, Key
+
+
+class MigrateDatasetProcessingStage:
+    def __init__(self, env, dry_run):
+        self.env = env
+        self.dry_run = dry_run
+        self.bucket = f"ok-origo-dataplatform-{env}"
+        self.metadata_api_url = "https://api.data{}.oslo.systems/metadata/".format(
+            "" if env == "prod" else "-dev"
+        )
+        self.s3 = boto3.client("s3")
+        self.dynamodb = boto3.resource("dynamodb", "eu-west-1")
+        self.metadata_table = self.dynamodb.Table("dataset-metadata")
+        self.pipeline_table = self.dynamodb.Table("pipeline")
+
+    def migrate(self, dataset, dest_stage, delete):
+        dataset_uri = f"{self.metadata_api_url}{self.env}/datasets/{dataset}"
+        print(f"Fetching dataset '{dataset}' metadata from {dataset_uri}")
+        resp = requests.get(dataset_uri)
+        if resp.status_code != 200:
+            raise ValueError(
+                f"Unable to fetch metadata for dataset '{dataset}': {resp}"
+            )
+
+        dataset_metadata = resp.json()
+        confidentiality = dataset_metadata["confidentiality"]
+        src_stage = dataset_metadata["processing_stage"]
+        if src_stage == dest_stage:
+            print(
+                f"Dataset '{dataset}' already migrated to stage '{dest_stage}', exiting."
+            )
+            return
+
+        print(
+            f"Migrating dataset '{dataset}' from stage '{src_stage}' to '{dest_stage}'"
+        )
+        print()
+
+        self.move_s3_files(dataset, confidentiality, src_stage, dest_stage, delete)
+        print()
+        self.update_output_stage(dataset, dest_stage)
+        print()
+        # self.update_pipeline_inputs(dataset, src_stage, dest_stage)
+        # print()
+        print("Done")
+
+    def move_s3_files(
+        self, dataset, confidentiality, src_stage, dest_stage, delete_src
+    ):
+        print(f"Moving S3 files from stage '{src_stage}' to '{dest_stage}'")
+
+        prefix = f"{src_stage}/{confidentiality}/{dataset}/"
+        response = self.s3.list_objects_v2(Bucket=self.bucket, Prefix=prefix)
+
+        # status_code = response["ResponseMetadata"]["HTTPStatusCode"]
+        if "Contents" not in response:
+            print(f"No files found in S3 ({prefix})")
+            return
+
+        keys = [o["Key"] for o in response["Contents"]]
+
+        for key in keys:
+            dest_key = dest_stage + key[key.index("/") :]
+            self.copy_file(key, dest_key)
+
+        if delete_src:
+            for key in keys:
+                self.delete_file(key)
+
+    def copy_file(self, src, dest):
+        print(f"Copying {src} to {dest}")
+        if not self.dry_run:
+            copy_source = {"Bucket": self.bucket, "Key": src}
+            response = self.s3.copy_object(
+                Bucket=self.bucket, CopySource=copy_source, Key=dest
+            )
+            status_code = response["ResponseMetadata"]["HTTPStatusCode"]
+            if status_code != 200 or "Error" in response:
+                print(f"Error copying file: {response}")
+                exit(1)
+
+    def delete_file(self, key):
+        print(f"Deleting {key}")
+        if not self.dry_run:
+            response = self.s3.delete_object(Bucket=self.bucket, Key=key)
+            status_code = response["ResponseMetadata"]["HTTPStatusCode"]
+            if status_code != 204 or "Error" in response:
+                print(f"Error deleting file: {response}")
+                exit(1)
+
+    def update_output_stage(self, dataset, stage):
+        print(f"Update dataset '{dataset}' output stage to '{stage}'")
+        if not self.dry_run:
+            self.metadata_table.update_item(
+                Key={"Type": "Dataset", "Id": dataset},
+                UpdateExpression="SET processing_stage = :ps",
+                ExpressionAttributeValues={":ps": stage},
+            )
+
+    def update_pipeline_inputs(self, dataset, src_stage, dest_stage):
+        print(
+            f"Update pipeline inputs for dataset '{dataset}' from stage '{src_stage}' to '{dest_stage}'"
+        )
+        # TODO handle version > 1
+        sort_key = f"input/{dataset}/1"
+
+        response = self.pipeline_table.query(
+            IndexName="GSI-1",
+            KeyConditionExpression=Key("SK(GSI-1-PK)").eq(sort_key),
+            FilterExpression=Attr("stage").eq(src_stage),
+        )
+
+        for item in response["Items"]:
+            pk = item["PK"]
+            print(f"Updating pipeline {pk}")
+
+            if not self.dry_run:
+                self.pipeline_table.update_item(
+                    Key={"PK": pk, "SK(GSI-1-PK)": sort_key},
+                    UpdateExpression="SET stage = :s",
+                    ExpressionAttributeValues={":s": dest_stage},
+                )

--- a/scripts/remove_processing_stage.py
+++ b/scripts/remove_processing_stage.py
@@ -1,0 +1,52 @@
+import argparse
+import os
+import time
+
+from boto3.dynamodb.conditions import Key
+
+# Must be done before repository import.
+os.environ["AWS_XRAY_SDK_ENABLED"] = "false"
+
+from metadata.dataset.repository import DatasetRepository  # noqa
+
+
+def query_all(table, **query):
+    """Return every result from `table` by evaluating `query`."""
+    res = table.query(**query)
+    items = res["Items"]
+
+    while "LastEvaluatedKey" in res:
+        time.sleep(1)  # Let's be nice
+        res = table.query(ExclusiveStartKey=res["LastEvaluatedKey"], **query)
+        items.extend(res["Items"])
+
+    return items
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", required=True, choices=["dev", "prod"])
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    os.environ["AWS_PROFILE"] = f"okdata-{args.env}"
+
+    print("Starting migration process, scanning for Type=Dataset")
+    repository = DatasetRepository()
+    items = query_all(
+        repository.metadata_table,
+        IndexName="IdByTypeIndex",
+        KeyConditionExpression=Key("Type").eq("Dataset"),
+    )
+
+    for item in items:
+        dataset_id = item["Id"]
+
+        print(f"Processing dataset-metadata.id={dataset_id}")
+
+        if args.apply:
+            print(f"\t\tNOT dry_run, removing processing_stage from {dataset_id}")
+            repository.metadata_table.update_item(
+                Key={"Id": id, "Type": "Dataset"},
+                UpdateExpression="REMOVE processing_stage",
+            )


### PR DESCRIPTION
Migrate two remaining legacy scripts from `okdata-scripts` (with slight adjustments to lose some dependencies). The others live on in `dataplatform-config`.