### PR TITLE
Read client secret at runtime

### DIFF
--- a/metadata/auth.py
+++ b/metadata/auth.py
@@ -1,6 +1,7 @@
 import os
 
 from keycloak import KeycloakOpenID
+from okdata.aws.ssm import get_secret
 from okdata.resource_auth import ResourceAuthorizer
 
 from metadata.dataset.repository import DatasetRepository
@@ -12,7 +13,9 @@ class Auth:
         self.KEYCLOAK_SERVER = "{}/auth/".format(os.environ["KEYCLOAK_SERVER"])
         self.KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM", "api-catalog")
         self.CLIENT_ID = os.environ["CLIENT_ID"]
-        self.CLIENT_SECRET = os.environ["CLIENT_SECRET"]
+        self.CLIENT_SECRET = get_secret(
+            "/dataplatform/metadata-api/keycloak-client-secret"
+        )
 
     def service_client_authorization_header(self):
         client = KeycloakOpenID(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile
 #
-annotated-types==0.5.0
-    # via pydantic
 anyio==4.0.0
     # via starlette
 arrow==1.2.3
@@ -19,7 +17,9 @@ aws-xray-sdk==2.12.0
 black==24.3.0
     # via metadata-api (setup.py)
 boto3==1.28.50
-    # via metadata-api (setup.py)
+    # via
+    #   metadata-api (setup.py)
+    #   okdata-aws
 botocore==1.31.50
     # via
     #   aws-xray-sdk
@@ -66,11 +66,11 @@ markupsafe==2.1.3
     #   metadata-api (setup.py)
 mypy-extensions==1.0.0
     # via black
-okdata-aws==1.0.1
+okdata-aws==4.0.0
     # via metadata-api (setup.py)
 okdata-resource-auth==0.1.4
     # via metadata-api (setup.py)
-okdata-sdk==2.4.1
+okdata-sdk==3.1.0
     # via okdata-aws
 packaging==23.1
     # via
@@ -84,10 +84,6 @@ pyasn1==0.5.0
     # via
     #   python-jose
     #   rsa
-pydantic==2.3.0
-    # via okdata-aws
-pydantic-core==2.6.3
-    # via pydantic
 pyjwt==2.8.0
     # via okdata-sdk
 python-dateutil==2.8.2
@@ -145,15 +141,12 @@ strict-rfc3339==0.7
     # via metadata-api (setup.py)
 structlog==23.1.0
     # via okdata-aws
-typing-extensions==4.8.0
-    # via
-    #   pydantic
-    #   pydantic-core
 uri-template==1.3.0
     # via jsonschema
 urllib3==1.26.18
     # via
     #   botocore
+    #   okdata-sdk
     #   requests
 webcolors==1.13
     # via jsonschema

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,6 @@ provider:
     KEYCLOAK_REALM: api-catalog
     RESOURCE_SERVER_CLIENT_ID: okdata-resource-server
     CLIENT_ID: metadata-api
-    CLIENT_SECRET: ${ssm:/dataplatform/${self:service}/keycloak-client-secret}
     BASE_URL: ${self:custom.baseUrl.${self:provider.stage}, self:custom.baseUrl.dev}
 
 plugins:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "simplejson",
         "jsonschema[format]",
         "strict-rfc3339",
-        "okdata-aws",
+        "okdata-aws>=2.1",
         "python-keycloak",
         "okdata-resource-auth",
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from unittest import mock
 
 import boto3
 import jsonschema
@@ -44,6 +45,13 @@ def auth_mock(requests_mock, mocker, monkeypatch):
         "service_client_authorization_header",
         return_value=client_credentials_header,
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_client_secret():
+    with mock.patch("metadata.auth.get_secret") as get_secret:
+        get_secret.return_value = "abc123"
+        yield get_secret
 
 
 @pytest.fixture(autouse=True)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ setenv =
     KEYCLOAK_REALM=mock
     RESOURCE_SERVER_CLIENT_ID=okdata-resource-server
     CLIENT_ID=mock
-    CLIENT_SECRET=mock
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
Read the Keycloak client secret from SSM at runtime instead of having it in the Lambda environment.