### PR TITLE
Move provenance information to new metadata property `wasDerivedFrom`

### DIFF
--- a/metadata/CommonRepository.py
+++ b/metadata/CommonRepository.py
@@ -56,12 +56,7 @@ class CommonRepository:
 
         return item
 
-    def get_items(
-        self,
-        parent_id=None,
-        source_type=None,
-        source_name=None,
-    ):
+    def get_items(self, parent_id=None, was_derived_from_name=None):
         log_add(dynamodb_item_type=self.type)
         key_condition = Key(TYPE_COLUMN).eq(self.type)
         filter_conditions = []
@@ -75,13 +70,11 @@ class CommonRepository:
                     f"{parent_id}/"
                 )
 
-        if source_type:
-            log_add(dynamodb_source_type=source_type)
-            filter_conditions.append(Attr("source.type").eq(source_type))
-
-        if source_name:
-            log_add(dynamodb_source_name=source_name)
-            filter_conditions.append(Attr("source.name").eq(source_name))
+        if was_derived_from_name:
+            log_add(dynamodb_was_derived_from_name=was_derived_from_name)
+            filter_conditions.append(
+                Attr("wasDerivedFrom.name").eq(was_derived_from_name)
+            )
 
         query_args = {
             "IndexName": "IdByTypeIndex",

--- a/metadata/dataset/handler.py
+++ b/metadata/dataset/handler.py
@@ -90,8 +90,7 @@ def get_datasets(event, context):
     datasets = dataset_repository.get_datasets(
         parent_id=query_params.get("parent_id"),
         api_id=query_params.get("api_id"),
-        source_type=query_params.get("source_type"),
-        source_name=query_params.get("source_name"),
+        was_derived_from_name=query_params.get("was_derived_from_name"),
     )
     log_add(num_datasets=len(datasets))
 

--- a/metadata/dataset/repository.py
+++ b/metadata/dataset/repository.py
@@ -50,18 +50,8 @@ class DatasetRepository(CommonRepository):
     def get_dataset(self, dataset_id, consistent_read=False):
         return self.get_item(dataset_id, consistent_read)
 
-    def get_datasets(
-        self,
-        parent_id=None,
-        api_id=None,
-        source_type=None,
-        source_name=None,
-    ):
-        datasets = self.get_items(
-            parent_id,
-            source_type,
-            source_name,
-        )
+    def get_datasets(self, parent_id=None, api_id=None, was_derived_from_name=None):
+        datasets = self.get_items(parent_id, was_derived_from_name)
 
         if api_id:
             db_response = log_dynamodb(

--- a/schema/dataset.json
+++ b/schema/dataset.json
@@ -148,12 +148,28 @@
           "type": "string",
           "maxLength": 255,
           "enum": [
-            "api",
             "database",
             "event",
             "file",
             "none"
           ]
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "wasDerivedFrom": {
+      "description": "Data provenance information",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "maxLength": 255
+        },
+        "id": {
+          "type": "string",
+          "maxLength": 255
         }
       },
       "required": [

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1013,13 +1013,24 @@ definitions:
               type: "string"
               maxLength: 255
               enum:
-              - "api"
               - "database"
               - "event"
               - "file"
               - "none"
           required:
           - "type"
+        wasDerivedFrom:
+          type: "object"
+          description: "Data provenance information"
+          properties:
+            name:
+              type: "string"
+              maxLength: 255
+            id:
+              type: "string"
+              maxLength: 255
+          required:
+            - "name"
         title:
           type: "string"
           description: "The dataset title"
@@ -1242,13 +1253,24 @@ definitions:
             type: "string"
             maxLength: 255
             enum:
-            - "api"
             - "database"
             - "event"
             - "file"
             - "none"
         required:
         - "type"
+      wasDerivedFrom:
+        type: "object"
+        description: "Data provenance information"
+        properties:
+          name:
+            type: "string"
+            maxLength: 255
+          id:
+            type: "string"
+            maxLength: 255
+        required:
+          - "name"
       title:
         type: "string"
         description: "The dataset title"

--- a/tests/dataset/handler_test.py
+++ b/tests/dataset/handler_test.py
@@ -522,16 +522,12 @@ class TestGetDataset:
     @pytest.mark.parametrize(
         "query_params,expected_result",
         [
-            ({"source_type": "api"}, {"ssb-foo", "ssb-bar", "okr-foo", "foo-bar"}),
-            ({"source_type": "api", "source_name": "ssb"}, {"ssb-foo", "ssb-bar"}),
-            ({"source_type": "api", "source_name": "foo"}, set()),
-            ({"source_name": "okr"}, {"okr-foo"}),
-            ({"source_type": "database"}, {"geo-foo"}),
-            ({"source_type": "database", "source_name": "foo"}, set()),
-            ({"source_name": "fooo"}, set()),
+            ({"was_derived_from_name": "ssb"}, {"ssb-foo", "ssb-bar"}),
+            ({"was_derived_from_name": "okr"}, {"okr-foo"}),
+            ({"was_derived_from_name": "bar"}, set()),
         ],
     )
-    def test_get_datasets_by_source(
+    def test_get_datasets_by_provenance(
         self,
         event,
         auth_event,
@@ -541,14 +537,17 @@ class TestGetDataset:
     ):
         import metadata.dataset.handler as dataset_handler
 
-        for distribution_id, source in [
-            ("ssb-foo", {"type": "api", "name": "ssb", "id": "1052"}),
-            ("ssb-bar", {"type": "api", "name": "ssb", "id": "1052"}),
-            ("okr-foo", {"type": "api", "name": "okr", "id": "X1y2Za"}),
-            ("foo-bar", {"type": "api"}),
-            ("geo-foo", {"type": "database", "database": "geo", "table": "foo"}),
+        for distribution_id, was_derived_from in [
+            ("ssb-foo", {"name": "ssb", "id": "1052"}),
+            ("ssb-bar", {"name": "ssb", "id": "1053"}),
+            ("okr-foo", {"name": "okr", "id": "X1y2Za"}),
+            ("foo-bar", {"name": "foo"}),
         ]:
-            dataset_item = {"Id": distribution_id, "Type": "Dataset", "source": source}
+            dataset_item = {
+                "Id": distribution_id,
+                "Type": "Dataset",
+                "wasDerivedFrom": was_derived_from,
+            }
             metadata_table.put_item(Item=dataset_item)
 
         res = dataset_handler.get_datasets(event(query_params=query_params), None)


### PR DESCRIPTION
Use new metadata property `wasDerivedFrom` for dataset source (provenance) information instead of existing, misused `source` property.