### PR TITLE
Don't crash on invalid JSON bodies

### DIFF
--- a/tests/common_test_helper.py
+++ b/tests/common_test_helper.py
@@ -69,22 +69,6 @@ def create_table(dynamodb, table_name, hashkey, rangekey=None, gsis=[]):
     )
 
 
-raw_dataset = {
-    "title": "Antall besøkende på gjenbruksstasjoner",
-    "description": "Sensordata fra tellere på gjenbruksstasjonene",
-    "keywords": ["avfall", "besøkende", "gjenbruksstasjon"],
-    "accrualPeriodicity": "hourly",
-    "accessRights": "non-public",
-    "objective": "Formålsbeskrivelse",
-    "license": "http://data.norge.no/nlod/no/1.0/",
-    "contactPoint": {
-        "name": "Tim",
-        "email": "tim@oslo.kommune.no",
-        "phone": "98765432",
-    },
-    "publisher": "REN",
-}
-
 dataset_updated = {
     "title": "UPDATED TITLE",
     "description": "Sensordata fra tellere på gamle gjenbruksstasjoner",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,12 +144,30 @@ def auth_event(*args, **kwargs):
     return lambda_event_factory(good_token)
 
 
+@pytest.fixture
+def raw_dataset():
+    return {
+        "title": "Antall besøkende på gjenbruksstasjoner",
+        "description": "Sensordata fra tellere på gjenbruksstasjonene",
+        "keywords": ["avfall", "besøkende", "gjenbruksstasjon"],
+        "accrualPeriodicity": "hourly",
+        "accessRights": "non-public",
+        "objective": "Formålsbeskrivelse",
+        "license": "http://data.norge.no/nlod/no/1.0/",
+        "contactPoint": {
+            "name": "Tim",
+            "email": "tim@oslo.kommune.no",
+            "phone": "98765432",
+        },
+        "publisher": "REN",
+    }
+
+
 @pytest.fixture()
-def put_dataset(auth_event):
+def put_dataset(auth_event, raw_dataset):
     from metadata.dataset import handler as dataset_handler
 
-    dataset = common_test_helper.raw_dataset.copy()
-    response = dataset_handler.create_dataset(auth_event(dataset), None)
+    response = dataset_handler.create_dataset(auth_event(raw_dataset), None)
     body = json.loads(response["body"])
     return body["Id"]
 

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -76,13 +76,12 @@ class TestCreateVersion:
         body = json.loads(response["body"])
         assert str.startswith(body[0]["message"], "Resource Conflict")
 
-    def test_forbidden(self, event, metadata_table):
+    def test_forbidden(self, event, metadata_table, raw_dataset):
         import metadata.version.handler as version_handler
 
-        dataset = common_test_helper.raw_dataset.copy()
-        dataset[ID_COLUMN] = "dataset-id"
-        dataset[TYPE_COLUMN] = "Dataset"
-        metadata_table.put_item(Item=dataset)
+        raw_dataset[ID_COLUMN] = "dataset-id"
+        raw_dataset[TYPE_COLUMN] = "Dataset"
+        metadata_table.put_item(Item=raw_dataset)
 
         version = common_test_helper.raw_version
         create_event = event(version, "dataset-id")
@@ -91,7 +90,7 @@ class TestCreateVersion:
         assert response["statusCode"] == 403
         assert json.loads(response["body"]) == [
             {
-                "message": f"You are not authorized to access dataset {dataset[ID_COLUMN]}"
+                "message": f"You are not authorized to access dataset {raw_dataset[ID_COLUMN]}"
             }
         ]
 


### PR DESCRIPTION
Improve the handling of invalid JSON bodies passed to the Lambdas by giving a 400 response instead of crashing.